### PR TITLE
Add `delay` parameter to `write` and `erase_*` calls

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 * Implement `Display` for `Error`
+* Add `delay` parameter to `write` and `erase_*` calls
 
 ## 0.2.0 - 2020-03-25
 


### PR DESCRIPTION
    Other than being a TODO in the code, this fixes write errors on an STM32
    board, caused by racy access to the spi status bit.
    
    On write/erase operations, the SPI flash will set a BUSY status bit to
    indicate the the operations are in progress.  We observed that at times
    write or erase operations would return immediately, and that the BUSY
    status bit would be set *after* the return from the call.  Adding the
    delay to the loop solved that problem.

There are at least two possible explanations for this:

1. The busy loop in wait_done() is somewhat optimized away or not
   checking properly the busy bit status.

2. There is some latency from the time the command is sent and the time
   the busy bit is set, so that wait_done() "does not catch it"

Unfortunately I do not have the means to check which one is the valid
explanation (if any!).  But adding the delay inside the loop as
suggested in the code did solve my problem, so here it is.
